### PR TITLE
SSH ciphers hardening

### DIFF
--- a/roles/centos/defaults/main.yml
+++ b/roles/centos/defaults/main.yml
@@ -219,3 +219,8 @@ centos_ssh_x11_forwarding: "no"
 # Setup key exchange algorithm. Default is the safest one, but if you need some compatilibity with other tools, please check http://ssh-comparison.quendi.de/comparison/kex.html this website
 centos_ssh_key_exchange_algorithms:
   - curve25519-sha256@libssh.org
+
+# List of keys for ssh server authentication. The defaults are the safest one. Path ( /etc/ssh ) should be omited
+centos_ssh_server_key_authentications:
+  - ssh_host_ed25519_key
+  - ssh_host_rsa_key

--- a/roles/centos/defaults/main.yml
+++ b/roles/centos/defaults/main.yml
@@ -229,7 +229,7 @@ centos_ssh_server_key_authentications:
   - ssh_host_ed25519_key
   - ssh_host_rsa_key
 
-# List of secure SSH ciphers. The default are the safest one.
+# List of SSH ciphers. The default are the safest one.
 centos_ssh_ciphers:
   - chacha20-poly1305@openssh.com
   - aes256-gcm@openssh.com
@@ -237,3 +237,14 @@ centos_ssh_ciphers:
   - aes256-ctr
   - aes192-ctr
   - aes128-ctr
+
+# List of MACs. The default are the safest one.
+centos_ssh_macs:
+  - hmac-sha2-512-etm@openssh.com
+  - hmac-sha2-256-etm@openssh.com
+  - hmac-ripemd160-etm@openssh.com
+  - umac-128-etm@openssh.com
+  - hmac-sha2-512
+  - hmac-sha2-256
+  - hmac-ripemd160
+  - umac-128@openssh.com

--- a/roles/centos/defaults/main.yml
+++ b/roles/centos/defaults/main.yml
@@ -197,6 +197,10 @@ centos_ssh_authentication_gss_api: "no"
 # Turn on or off Kerberos authentication (valid values: "yes" | "no")
 centos_ssh_authentication_kerberos: "no"
 
+# Turn on or off PAM-based authentication (valid values: "yes" | "no")
+# If you will set centos_ssh_authentication_password to "no", you should set this to "no" as well to trully disable password authentication.
+centos_ssh_challenge_response: "no"
+
 # Turn on or off logging in as root (valid values: "yes" | "no")
 centos_ssh_login_as_root: "no"
 

--- a/roles/centos/defaults/main.yml
+++ b/roles/centos/defaults/main.yml
@@ -228,3 +228,12 @@ centos_ssh_key_exchange_algorithms:
 centos_ssh_server_key_authentications:
   - ssh_host_ed25519_key
   - ssh_host_rsa_key
+
+# List of secure SSH ciphers. The default are the safest one.
+centos_ssh_ciphers:
+  - chacha20-poly1305@openssh.com
+  - aes256-gcm@openssh.com
+  - aes128-gcm@openssh.com
+  - aes256-ctr
+  - aes192-ctr
+  - aes128-ctr

--- a/roles/centos/defaults/main.yml
+++ b/roles/centos/defaults/main.yml
@@ -215,3 +215,7 @@ centos_ssh_ignore_rhosts: "yes"
 
 # Turn on or off X11 Forwarding (valid values: "yes" | "no")
 centos_ssh_x11_forwarding: "no"
+
+# Setup key exchange algorithm. Default is the safest one, but if you need some compatilibity with other tools, please check http://ssh-comparison.quendi.de/comparison/kex.html this website
+centos_ssh_key_exchange_algorithms:
+  - curve25519-sha256@libssh.org

--- a/roles/centos/tasks/ssh.yml
+++ b/roles/centos/tasks/ssh.yml
@@ -26,6 +26,15 @@
   notify: restart sshd
   tags: [centos, ssh]
 
+- name: Configure PAM authentication
+  lineinfile:
+    dest: "{{ centos_ssh_config_file }}"
+    line: "ChallengeResponseAuthentication {{ centos_ssh_challenge_response }}"
+    state: present
+    regexp: '^#?ChallengeResponseAuthentication'
+  notify: restart sshd
+  tags: [centos, ssh]
+
 - name: Configure GSS API authentication
   lineinfile:
     dest: "{{ centos_ssh_config_file }}"

--- a/roles/centos/tasks/ssh.yml
+++ b/roles/centos/tasks/ssh.yml
@@ -232,6 +232,20 @@
 
 
 
+# Configure authentication codes
+# They provide integrity for encryption. Only secure algorithms should be used
+#
+- name: Configure SSH MACs
+  lineinfile:
+    dest: "{{ centos_ssh_config_file }}"
+    line: "MACs {{ centos_ssh_macs | join (',') }}"
+    state: present
+    regexp: '^#?MACs'
+  notify: restart sshd
+  tags: [centos, ssh]
+
+
+
 # Make sure that sshd service is started and enabled on boot
 #
 - name: Make sure that sshd service is started and enabled on boot

--- a/roles/centos/tasks/ssh.yml
+++ b/roles/centos/tasks/ssh.yml
@@ -180,6 +180,30 @@
     dest: "{{ centos_ssh_config_file }}"
     line: "KexAlgorithms {{ centos_ssh_key_exchange_algorithms | join (',') }}"
     state: present
+    regexp: '^#?KexAlgorithms'
+  notify: restart sshd
+  tags: [centos, ssh]
+
+
+
+# Setup SSH server authentication
+# Same as in key exchange, there are some algorithms that are less secure than others.
+# We should only keep the secure ones.
+#
+- name: Enable secure keys for server authentication
+  lineinfile:
+    dest: "{{ centos_ssh_config_file }}"
+    line: "HostKey /etc/ssh/{{ item }}"
+    state: present
+  with_items: "{{ centos_ssh_server_key_authentications }}"
+  notify: restart sshd
+  tags: [centos, ssh]
+
+- name: Remove all other keys for server authentication
+  lineinfile:
+    dest: "{{ centos_ssh_config_file }}"
+    regexp: "HostKey /etc/ssh/(?!{{ centos_ssh_server_key_authentications | join('|') }})"
+    state: absent
   notify: restart sshd
   tags: [centos, ssh]
 

--- a/roles/centos/tasks/ssh.yml
+++ b/roles/centos/tasks/ssh.yml
@@ -218,9 +218,23 @@
 
 
 
+# Setup SSH connection ciphers
+# They are used to encrypt the data after authentication. You should only use secure ciphers, that are not easy to break
+#
+- name: Configure SSH ciphers
+  lineinfile:
+    dest: "{{ centos_ssh_config_file }}"
+    line: "Ciphers {{ centos_ssh_ciphers | join (',') }}"
+    state: present
+    regexp: '^#?Ciphers'
+  notify: restart sshd
+  tags: [centos, ssh]
+
+
+
 # Make sure that sshd service is started and enabled on boot
 #
-- name: Start sshd service
+- name: Make sure that sshd service is started and enabled on boot
   service:
     name: sshd
     state: started

--- a/roles/centos/tasks/ssh.yml
+++ b/roles/centos/tasks/ssh.yml
@@ -172,6 +172,19 @@
 
 
 
+# Setup SSH key exchange
+# Not all key exchange algorithms are secure enough, so we can disable some of them
+#
+- name: Configure key exchange
+  lineinfile:
+    dest: "{{ centos_ssh_config_file }}"
+    line: "KexAlgorithms {{ centos_ssh_key_exchange_algorithms | join (',') }}"
+    state: present
+  notify: restart sshd
+  tags: [centos, ssh]
+
+
+
 # Make sure that sshd service is started and enabled on boot
 #
 - name: Start sshd service


### PR DESCRIPTION
Add some more hardening to SSH:
- Key exchange hardening
- Server key authentication hardening
- Disable PAM-based authentication
- Configure SSH ciphers and MACs
