### PR TITLE
Httpd update

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You can setup logrotate scripts with this role as well.
 
 **git** - Compile git from source with OpenSSL (2.15.1) 
 
-**httpd** - Install and configure latest version of Apache httpd (2.4.27)
+**httpd** - Compile and configure Apache httpd from source with OpenSSL (2.4.29)
 
 **nodejs** - Install latest version of Node.js (8.3.0) and NPM
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -6,4 +6,4 @@ Each package have it's own release cycle. Here is the list of URLs that we check
 * [CentOS/NTP](https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7) 7.4.1708
 * [OpenSSL](https://github.com/openssl/openssl/releases) 1.1.0g
 * [Git](https://github.com/git/git/releases) 2.15.1
-* [HTTPD](https://github.com/apache/httpd/releases) 2.15.1
+* [HTTPD](https://github.com/apache/httpd/releases) 2.4.29

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -6,3 +6,4 @@ Each package have it's own release cycle. Here is the list of URLs that we check
 * [CentOS/NTP](https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7) 7.4.1708
 * [OpenSSL](https://github.com/openssl/openssl/releases) 1.1.0g
 * [Git](https://github.com/git/git/releases) 2.15.1
+* [HTTPD](https://github.com/apache/httpd/releases) 2.15.1

--- a/roles/centos/defaults/main.yml
+++ b/roles/centos/defaults/main.yml
@@ -169,6 +169,7 @@ centos_yum_other_packages:
  - lsscsi
  - lvm2 # dependencies: device-mapper-persistent-data
  - make
+ - mdadm # dependencies: libreport-filesystem
  - microcode_ctl
  - mozjs17
  - nettle # dependencies: gnutls

--- a/roles/httpd/README.md
+++ b/roles/httpd/README.md
@@ -2,7 +2,7 @@ HTTPD role
 ==========
 
 This role will install Apache httpd https://httpd.apache.org/ server on CentOS.
-Apache httpd will be installed in latest version (2.4.27) and will be compiled from source.
+Apache httpd will be installed in 2.4.29 version and will be compiled from source.
 
 What you should know?
 ---------------------

--- a/roles/httpd/defaults/main.yml
+++ b/roles/httpd/defaults/main.yml
@@ -79,6 +79,7 @@ httpd_active_modules:
  - authz_host
  - dir
  - deflate
+ - expires
  - filter
  - http2
  - log_config
@@ -128,6 +129,22 @@ httpd_gzip_mime_types:
  - text/html
  - text/plain
  - text/xml
+
+# Enable expires header for browser caching
+httpd_enable_expires_headers: yes
+
+# List of mime types that should have added expires header
+httpd_expires_mime_types:
+  - image/gif
+  - image/ico
+  - image/jpg
+  - image/jpeg
+  - image/png
+  - text/css
+  - text/javascript
+
+# Timeout for expires. Will be used in "access plus ..."
+httpd_expires_timeout: "1 week"
 
 # Enable SSL encryption
 httpd_enable_ssl: yes

--- a/roles/httpd/defaults/main.yml
+++ b/roles/httpd/defaults/main.yml
@@ -15,13 +15,13 @@ httpd_manage_virtualhosts: yes
 ####### INSTALL TASKS CONFIGURATION #######
 
 # Version of Apache httpd that should be present in the system
-httpd_version: "2.4.27"
+httpd_version: "2.4.29"
 
 # Version of APR library required for compiling Apache httpd
-httpd_apr_version: "1.6.2"
+httpd_apr_version: "1.6.3"
 
 # Version fo APR-util requried for compiling Apache httpd
-httpd_apr_util_version: "1.6.0"
+httpd_apr_util_version: "1.6.1"
 
 # Location of files for Apache httpd sources
 httpd_sources_location: /usr/src

--- a/roles/httpd/tasks/configure.yml
+++ b/roles/httpd/tasks/configure.yml
@@ -197,7 +197,7 @@
     group: root
     mode: 0644
   when: "httpd_enable_gzip_compression == true"
-  tags: [httpd, configure, t2]
+  tags: [httpd, configure]
 
 - name: Make sure that gzip compression is enabled
   lineinfile:
@@ -217,6 +217,41 @@
     regexp: '^#?Include\ conf\/extra/\httpd-deflate'
   notify: restart httpd
   when: "httpd_enable_gzip_compression == false"
+  tags: [httpd, configure]
+
+
+
+# Configure mod_expires
+# mod_expires handle expiration headers for given mime types
+#
+- name: Add separate config file with expires configuration
+  template:
+    src: httpd-expires.conf.j2
+    dest: "{{ httpd_install_path }}/conf/extra/httpd-expires.conf"
+    owner: root
+    group: root
+    mode: 0644
+  when: "httpd_enable_expires_headers == true"
+  tags: [httpd, configure]
+
+- name: Make sure that expires headers are enabled
+  lineinfile:
+    dest: "{{ httpd_config_file }}"
+    line: "Include conf/extra/httpd-expires.conf"
+    state: present
+    regexp: '^#?Include\ conf\/extra/\httpd-expires'
+  notify: restart httpd
+  when: "httpd_enable_expires_headers == true"
+  tags: [httpd, configure]
+
+- name: Make sure that expires headers are disabled
+  lineinfile:
+    dest: "{{ httpd_config_file }}"
+    line: "#Include conf/extra/httpd-expires.conf"
+    state: present
+    regexp: '^#?Include\ conf\/extra/\httpd-expires'
+  notify: restart httpd
+  when: "httpd_enable_expires_headers == false"
   tags: [httpd, configure]
 
 

--- a/roles/httpd/tasks/install.yml
+++ b/roles/httpd/tasks/install.yml
@@ -1,3 +1,13 @@
+# Install epel-release that provides libnghttp2-devel package required for compilation with HTTP2
+#
+- name: Install epel-release for libnghttp2-devel package
+  yum:
+    name: epel-release
+    state: latest
+  tags: [httpd, install]
+
+
+
 # Install required software for compiling Apache httpd from source
 #
 - name: Install required tools for compiling Apache httpd
@@ -6,6 +16,7 @@
     state: latest
   with_items:
     - autoconf # Dependencies: m4 perl perl-Carp perl-Data-Dumper perl-Encode perl-Exporter perl-File-Path perl-File-Temp perl-Filter perl-Getopt-Long perl-HTTP-Tiny perl-PathTools perl-Pod-Escapes perl-Pod-Perldoc perl-Pod-Simple perl-Pod-Usage perl-Scalar-List-Utils perl-Socket perl-Storable perl-Text-ParseWords perl-Time-HiRes perl-Time-Local perl-constant perl-libs perl-macros perl-parent perl-podlators perl-threads perl-threads-shared
+    - expat-devel
     - libtool # Dependencies: autoconf automake cpp gcc glibc-devel glibc-headers kernel-headers libmpc m4 mpfr perl perl-Carp perl-Data-Dumper perl-Encode perl-Exporter perl-File-Path perl-File-Temp perl-Filter perl-Getopt-Long perl-HTTP-Tiny perl-PathTools perl-Pod-Escapes perl-Pod-Perldoc perl-Pod-Simple perl-Pod-Usage perl-Scalar-List-Utils perl-Socket perl-Storable perl-Test-Harness perl-Text-ParseWords perl-Thread-Queue perl-Time-HiRes perl-Time-Local perl-constant perl-libs perl-macros perl-parent perl-podlators perl-threads perl-threads-shared
     - libnghttp2-devel # Dependencies: libnghttp2
     - pcre-devel

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -48,21 +48,21 @@
 #  1. Apache httpd is not installed
 #  2. Apache httpd is installed but not in desired version
 #
-- include: install.yml
+- import_tasks: install.yml
   when: "httpd_install_new_version == true and httpd_manage_installation == true"
 
 
 
 # Configure Apache httpd
 #
-- include: configure.yml
+- import_tasks: configure.yml
   when: "httpd_manage_configuration == true"
 
 
 
 # Configure Apache httpd VirtualHosts
 #
-- include: virtualhosts.yml
+- import_tasks: virtualhosts.yml
   when: "httpd_manage_virtualhosts == true"
 
 

--- a/roles/httpd/templates/httpd-expires.conf.j2
+++ b/roles/httpd/templates/httpd-expires.conf.j2
@@ -1,0 +1,12 @@
+<IfModule mod_expires.c>
+  # Enable expirations
+  ExpiresActive On
+
+  # Default directive
+  ExpiresDefault "access plus 1 month"
+
+  # Expirations for given mime type
+{% for mime in httpd_expires_mime_types %}
+  ExpiresByType {{ mime }} "access plus {{ httpd_expires_timeout }}"
+{% endfor %}
+</IfModule>


### PR DESCRIPTION
Update Apache httpd to 2.4.29
Fix installation issues with Apache httpd (missing libraries)
Configure mod_expires
Fix Ansible warnings with import_tasks
Add missing mdadm for kernel package when using CentOS with RAID