### PR TITLE
Nodejs role

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Included roles
 
 **awscli** - Install and configure AWS CLI command line tool (2.1.25)
 
-**redis** - Install and configure Redis with TLS support (6.0.6)
+**redis** - Install and configure Redis with TLS support (6.0.10)
 
 **centos** - Takes care of system settings. Set up firewall based on iptables. Disable Transparent Huge Pages.
 You can setup logrotate scripts with this role as well.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Included roles
 
 **git** - Compile and install Git from source (2.30.1) 
 
-**nginx** - Compile, install and configure nginx from source (1.19.0)
+**nginx** - Compile, install and configure nginx from source (1.19.6)
 
 **php** - Compile, install and configure PHP and tools (7.4.7)
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Included roles
 
 **redis** - Install and configure Redis with TLS support (6.0.10)
 
-**nodejs** - Install Node.js and NPM (15.8.0)
+**nodejs** - Install Node.js and NPM (15.9.0)
 
 **centos** - Takes care of system settings. Set up firewall based on iptables. Disable Transparent Huge Pages.
 You can setup logrotate scripts with this role as well.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Included roles
 
 **openssl** - Compile OpenSSL from source (1.1.1i)
 
-**git** - Compile and install Git from source (2.27.0) 
+**git** - Compile and install Git from source (2.30.1) 
 
 **nginx** - Compile, install and configure nginx from source (1.19.0)
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Included roles
 
 **ntp** - Takes care of system timezone and NTP server. It uses Chrony for using NTP.
 
-**openssl** - Compile OpenSSL from source (1.1.1g)
+**openssl** - Compile OpenSSL from source (1.1.1i)
 
 **git** - Compile and install Git from source (2.27.0) 
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Included roles
 
 **mysql** - Install and configure MySQL community server (8.0.23). Create databases and users. Install MySQLTuner and setup backups.
 
-**awscli** - Install and configure AWS CLI command line tool (2.0.28)
+**awscli** - Install and configure AWS CLI command line tool (2.1.25)
 
 **redis** - Install and configure Redis with TLS support (6.0.6)
 

--- a/README.md
+++ b/README.md
@@ -66,12 +66,12 @@ Included roles
 
 **redis** - Install and configure Redis with TLS support (6.0.10)
 
+**nodejs** - Install Node.js and NPM (15.8.0)
+
 **centos** - Takes care of system settings. Set up firewall based on iptables. Disable Transparent Huge Pages.
 You can setup logrotate scripts with this role as well.
 
 **httpd** - Compile and configure Apache httpd from source with OpenSSL (2.4.33)
-
-**nodejs** - Install latest version of Node.js (8.3.0) and NPM
 
 **datadog** - Install and configure DataDog agent with multiple integrations.
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Included roles
 
 **firewalld** - Setup firewalld as base firewall
 
-**mysql** - Install and configure MySQL community server (8.0.21). Create databases and users. Install MySQLTuner and setup backups.
+**mysql** - Install and configure MySQL community server (8.0.23). Create databases and users. Install MySQLTuner and setup backups.
 
 **awscli** - Install and configure AWS CLI command line tool (2.0.28)
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Included roles
 
 **nginx** - Compile, install and configure nginx from source (1.19.6)
 
-**php** - Compile, install and configure PHP and tools (7.4.7)
+**php** - Compile, install and configure PHP and tools (8.0.2)
 
 **firewalld** - Setup firewalld as base firewall
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -11,5 +11,5 @@ Each package have it's own release cycle. Here is the list of URLs that we check
 * [MySQL](https://dev.mysql.com/downloads/mysql/) 8.0.23
 * [AWS CLI](https://github.com/aws/aws-cli/releases) 2.1.25
 * [Redis](https://redis.io/download) 6.0.10
-* [NodeJs](https://nodejs.org/en/) 15.8.0
+* [NodeJs](https://nodejs.org/en/) 15.9.0
 * [HTTPD](https://github.com/apache/httpd/releases) 2.4.33

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -10,5 +10,5 @@ Each package have it's own release cycle. Here is the list of URLs that we check
 * [PHP](https://github.com/php/php-src/releases) 8.0.2
 * [MySQL](https://dev.mysql.com/downloads/mysql/) 8.0.23
 * [AWS CLI](https://github.com/aws/aws-cli/releases) 2.1.25
-* [Redis](https://redis.io/download) 6.0.6
+* [Redis](https://redis.io/download) 6.0.10
 * [HTTPD](https://github.com/apache/httpd/releases) 2.4.33

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -8,7 +8,7 @@ Each package have it's own release cycle. Here is the list of URLs that we check
 * [Git](https://github.com/git/git/releases) 2.30.1
 * [nginx](https://nginx.org/en/download.html) 1.19.6
 * [PHP](https://github.com/php/php-src/releases) 8.0.2
-* [MySQL](https://dev.mysql.com/downloads/mysql/) 8.0.21
+* [MySQL](https://dev.mysql.com/downloads/mysql/) 8.0.23
 * [AWS CLI](https://github.com/aws/aws-cli/releases) 2.0.28
 * [Redis](https://redis.io/download) 6.0.6
 * [HTTPD](https://github.com/apache/httpd/releases) 2.4.33

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -11,4 +11,5 @@ Each package have it's own release cycle. Here is the list of URLs that we check
 * [MySQL](https://dev.mysql.com/downloads/mysql/) 8.0.23
 * [AWS CLI](https://github.com/aws/aws-cli/releases) 2.1.25
 * [Redis](https://redis.io/download) 6.0.10
+* [NodeJs](https://nodejs.org/en/) 15.8.0
 * [HTTPD](https://github.com/apache/httpd/releases) 2.4.33

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -3,7 +3,7 @@ Current Versions
 
 Each package have it's own release cycle. Here is the list of URLs that we check for new versions:
 
-* [CentOS](https://wiki.centos.org/Manuals/ReleaseNotes) 8.2.2004
+* [CentOS](https://wiki.centos.org/Manuals/ReleaseNotes) 8.3.2011
 * [OpenSSL](https://github.com/openssl/openssl/releases) 1.1.1g
 * [Git](https://github.com/git/git/releases) 2.27.0
 * [nginx](https://nginx.org/en/download.html) 1.19.0

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -5,7 +5,7 @@ Each package have it's own release cycle. Here is the list of URLs that we check
 
 * [CentOS](https://wiki.centos.org/Manuals/ReleaseNotes) 8.3.2011
 * [OpenSSL](https://github.com/openssl/openssl/releases) 1.1.1i
-* [Git](https://github.com/git/git/releases) 2.27.0
+* [Git](https://github.com/git/git/releases) 2.30.1
 * [nginx](https://nginx.org/en/download.html) 1.19.0
 * [PHP](https://github.com/php/php-src/releases) 7.4.7
 * [MySQL](https://dev.mysql.com/downloads/mysql/) 8.0.21

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -6,7 +6,7 @@ Each package have it's own release cycle. Here is the list of URLs that we check
 * [CentOS](https://wiki.centos.org/Manuals/ReleaseNotes) 8.3.2011
 * [OpenSSL](https://github.com/openssl/openssl/releases) 1.1.1i
 * [Git](https://github.com/git/git/releases) 2.30.1
-* [nginx](https://nginx.org/en/download.html) 1.19.0
+* [nginx](https://nginx.org/en/download.html) 1.19.6
 * [PHP](https://github.com/php/php-src/releases) 7.4.7
 * [MySQL](https://dev.mysql.com/downloads/mysql/) 8.0.21
 * [AWS CLI](https://github.com/aws/aws-cli/releases) 2.0.28

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,7 +4,7 @@ Current Versions
 Each package have it's own release cycle. Here is the list of URLs that we check for new versions:
 
 * [CentOS](https://wiki.centos.org/Manuals/ReleaseNotes) 8.3.2011
-* [OpenSSL](https://github.com/openssl/openssl/releases) 1.1.1g
+* [OpenSSL](https://github.com/openssl/openssl/releases) 1.1.1i
 * [Git](https://github.com/git/git/releases) 2.27.0
 * [nginx](https://nginx.org/en/download.html) 1.19.0
 * [PHP](https://github.com/php/php-src/releases) 7.4.7

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -9,6 +9,6 @@ Each package have it's own release cycle. Here is the list of URLs that we check
 * [nginx](https://nginx.org/en/download.html) 1.19.6
 * [PHP](https://github.com/php/php-src/releases) 8.0.2
 * [MySQL](https://dev.mysql.com/downloads/mysql/) 8.0.23
-* [AWS CLI](https://github.com/aws/aws-cli/releases) 2.0.28
+* [AWS CLI](https://github.com/aws/aws-cli/releases) 2.1.25
 * [Redis](https://redis.io/download) 6.0.6
 * [HTTPD](https://github.com/apache/httpd/releases) 2.4.33

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -7,7 +7,7 @@ Each package have it's own release cycle. Here is the list of URLs that we check
 * [OpenSSL](https://github.com/openssl/openssl/releases) 1.1.1i
 * [Git](https://github.com/git/git/releases) 2.30.1
 * [nginx](https://nginx.org/en/download.html) 1.19.6
-* [PHP](https://github.com/php/php-src/releases) 7.4.7
+* [PHP](https://github.com/php/php-src/releases) 8.0.2
 * [MySQL](https://dev.mysql.com/downloads/mysql/) 8.0.21
 * [AWS CLI](https://github.com/aws/aws-cli/releases) 2.0.28
 * [Redis](https://redis.io/download) 6.0.6

--- a/roles/awscli/defaults/main.yml
+++ b/roles/awscli/defaults/main.yml
@@ -1,5 +1,5 @@
 # Version of AWS CLI to install
-awscli_version: 2.0.28
+awscli_version: 2.1.25
 
 # Where to download AWS CLI zip file
 awscli_zip_file_location: /usr/src

--- a/roles/dnf/README.md
+++ b/roles/dnf/README.md
@@ -1,7 +1,7 @@
 DNF role
 ==========
 
-This role is responsible for upgrading, installing and removing packages with DNF package manager. 
+This role is responsible for upgrading, installing, and removing packages with the DNF package manager.
 It also contains some security checks for GPG validation during package management.
 This role also installs `dnf-automatic` to speed up package installation.
 
@@ -10,9 +10,9 @@ Variables
 ---------
 Here is the list of configurable variables for this role:
 
- - `dnf_packages_to_remove` by default is empty, but you can add the packages you wish to remove here.
- 
- - `dnf_packages_to_install` list of additional tools to install. By default it's empty.
+- `dnf_packages_to_remove` by default is empty, but you can add the packages you wish to remove here.
 
- - `dnf_exclude_packages_to_upgrade` packages that will be excluded from upgrades. It is helpful when you wish to manage default packages but for instance you don't want to install new version of MySQL etc. By default there are the packages that are managed by other roles like MongoDB, MySQL and Node.js. All other packages will be updated to latest version.
+- `dnf_packages_to_install` list of additional tools to install. By default, it's empty.
+
+- `dnf_exclude_packages_to_upgrade` packages that will be excluded from upgrades. It is helpful when you wish to manage default packages but for instance, you don't want to install a new version of MySQL, etc. By default, there are the packages that are managed by other roles like MongoDB, MySQL, and Node.js. All other packages will be updated to the latest version.
  

--- a/roles/dnf/tasks/main.yml
+++ b/roles/dnf/tasks/main.yml
@@ -48,7 +48,7 @@
     name: dnf-automatic-download.timer
     state: started
     enabled: yes
-  tags: [dnf, skip-on-local]
+  tags: [dnf, local]
 
 
 

--- a/roles/dnf/tasks/main.yml
+++ b/roles/dnf/tasks/main.yml
@@ -48,7 +48,7 @@
     name: dnf-automatic-download.timer
     state: started
     enabled: yes
-  tags: [dnf]
+  tags: [dnf, skip-on-local]
 
 
 
@@ -120,6 +120,6 @@
   tags: [dnf]
 
 - debug:
-    msg: "List of packages available for upgrade: {{ dnf_not_upgraded.results | map(attribute='name') | join(', ') }}"
+    msg: "List of packages available for upgrade: {{ dnf_not_upgraded.results | map(attribute='name') | unique | join(', ') }}"
   when: "dnf_not_upgraded.results | length > 0"
   tags: [dnf]

--- a/roles/git/defaults/main.yml
+++ b/roles/git/defaults/main.yml
@@ -1,5 +1,5 @@
 # Version of git that should be installed
-git_version: "2.27.0"
+git_version: "2.30.1"
 
 # Location where Git should be installed
 git_install_path: /usr/local/git

--- a/roles/mysql/defaults/main.yml
+++ b/roles/mysql/defaults/main.yml
@@ -1,5 +1,5 @@
 # Version of MySQL that should be installed
-mysql_version: "8.0.21"
+mysql_version: "8.0.23"
 
 # MySQL root password
 mysql_root_password: "rKp#rX3EP?Y2JGug*q,s>F,)@Hbuf9KCH#Z8odF44!)vH7MmrwJ4"

--- a/roles/mysql/handlers/main.yml
+++ b/roles/mysql/handlers/main.yml
@@ -2,3 +2,4 @@
   service:
     name: mysqld
     state: restarted
+  tags: [local]

--- a/roles/mysql/tasks/backup.yml
+++ b/roles/mysql/tasks/backup.yml
@@ -62,4 +62,4 @@
     job: "bash {{ item.value.backup_directory }}/{{ item.key }}-backup.sh >> {{ item.value.backup_directory }}/{{ item.key }}-backup.log 2>&1"
   with_items: "{{ mysql_backup_databases }}"
   when: "mysql_backup_databases is defined"
-  tags: [mysql]
+  tags: [mysql, local]

--- a/roles/mysql/tasks/install.yml
+++ b/roles/mysql/tasks/install.yml
@@ -14,5 +14,5 @@
   dnf:
     name: "mysql-community-server-{{ mysql_version }}"
     state: latest
-    disablerepo: AppStream
+    disablerepo: appstream
   tags: [mysql]

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -22,7 +22,7 @@
     name: mysqld
     state: started
     enabled: yes
-  tags: [mysql]
+  tags: [mysql, local]
 
 
 

--- a/roles/mysql/tasks/root-password.yml
+++ b/roles/mysql/tasks/root-password.yml
@@ -38,7 +38,7 @@
     filter: version
   ignore_errors: yes
   register: mysql_root_password_test
-  tags: [mysql]
+  tags: [mysql, local]
 
 - name: Create init file with new root password
   template:
@@ -48,34 +48,34 @@
     group: mysql
     mode: 0644
   when: "mysql_root_password_test.failed"
-  tags: [mysql]
+  tags: [mysql, local]
 
 - name: Stop MySQL server
   service:
     name: mysqld
     state: stopped
   when: "mysql_root_password_test.failed"
-  tags: [mysql]
+  tags: [mysql, local]
 
 - name: Start MySQL server with init file
   shell: /usr/sbin/mysqld --init-file=/tmp/mysql-init-file  --user=mysql &
   when: "mysql_root_password_test.failed"
-  tags: [mysql]
+  tags: [mysql, local]
 
 - name: Remove init file
   file:
     path: /tmp/mysql-init-file
     state: absent
-  tags: [mysql]
+  tags: [mysql, local]
 
 - name: Kill server with init file
   shell: kill `ps aux | grep /usr/sbin/mysqld | grep -v grep | awk '{print $2}'`
   when: "mysql_root_password_test.failed"
-  tags: [mysql]
+  tags: [mysql, local]
 
 - name: Start MySQL server
   service:
     name: mysqld
     state: started
   when: "mysql_root_password_test.failed"
-  tags: [mysql]
+  tags: [mysql, local]

--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -1,5 +1,5 @@
 # Version of nginx that should be installed
-nginx_version: "1.19.0"
+nginx_version: "1.19.6"
 
 # Path where nginx will be installed. NO trailing slash at the end!
 nginx_install_path: /usr/local/nginx
@@ -17,7 +17,7 @@ nginx_build_group: developer
 nginx_pcre_version: "8.44"
 
 # Version of OpenSSL that will be compiled with nginx
-nginx_openssl_version: "1.1.1g"
+nginx_openssl_version: "1.1.1i"
 
 # Version of Zlib that will be compiled with nginx
 nginx_zlib_version: "1.2.11"

--- a/roles/nginx/handlers/main.yml
+++ b/roles/nginx/handlers/main.yml
@@ -2,3 +2,4 @@
   service:
     name: nginx
     state: restarted
+    tags: [local]

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -31,4 +31,4 @@
     name: nginx
     state: started
     enabled: yes
-  tags: [nginx, healthcheck]
+  tags: [nginx, healthcheck, local]

--- a/roles/nodejs/README.md
+++ b/roles/nodejs/README.md
@@ -1,5 +1,12 @@
 Node.js role
 ============
 
-This role will install Node.js 7.* version on CentOS system.
-Currently Node.js 6.* is not supported in that role.
+This role will install [Node.js](https://nodejs.org/en/) and configured global packages.
+
+Variables
+---------
+Here is the list of configurable variables for this role:
+
+- `nodejs_version` version of Node.JS to install.
+
+- `nodejs_global_packages` list of packages that should be installed globally using NPM. By default, the list is empty.

--- a/roles/nodejs/defaults/main.yml
+++ b/roles/nodejs/defaults/main.yml
@@ -1,5 +1,5 @@
 # Node.js version
-nodejs_version: "15.8.0"
+nodejs_version: "15.9.0"
 
 # Global packages (list of packages installed with -g option)
 nodejs_global_packages: []

--- a/roles/nodejs/defaults/main.yml
+++ b/roles/nodejs/defaults/main.yml
@@ -1,5 +1,5 @@
 # Node.js version
-nodejs_version: "8.3.0"
+nodejs_version: "15.8.0"
 
 # Global packages (list of packages installed with -g option)
 nodejs_global_packages: []

--- a/roles/nodejs/tasks/install.yml
+++ b/roles/nodejs/tasks/install.yml
@@ -1,30 +1,20 @@
-# Make sure that libselinux-python is installed (required for Ansible templates)
-#
-- name: Make sure that libselinux-python is installed
-  yum:
-    name: libselinux-python
-    state: latest
-  tags: [nodejs, install]
-
-
-
 # Node.js has it's own repository. In order to have it available we need to add it to Yum repositories
 #
 - name: Make sure that Node.js repository is available
   template:
-    src: nodesource-el7.repo.j2
-    dest: /etc/yum.repos.d/nodejs.repo
+    src: nodesource-el8.repo.j2
+    dest: /etc/yum.repos.d/nodesource-el8.repo
     owner: root
     group: root
     mode: 0644
-  tags: [nodejs, install]
+  tags: [nodejs]
 
 
 
 # Install Node.js and NPM
 #
 - name: Install Node.js and NPM
-  yum:
+  dnf:
     name: "nodejs-{{ nodejs_version }}"
-    state: present
-  tags: [nodejs, install]
+    state: latest
+  tags: [nodejs]

--- a/roles/nodejs/tasks/install.yml
+++ b/roles/nodejs/tasks/install.yml
@@ -11,10 +11,21 @@
 
 
 
+# Import RPM key
+#
+- name: Import NodeSource RPM key
+  rpm_key:
+    key: https://rpm.nodesource.com/pub/el/NODESOURCE-GPG-SIGNING-KEY-EL
+    state: present
+  tags: [nodejs]
+
+
+
 # Install Node.js and NPM
 #
 - name: Install Node.js and NPM
   dnf:
     name: "nodejs-{{ nodejs_version }}"
     state: latest
+    disablerepo: appstream
   tags: [nodejs]

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -24,6 +24,6 @@
   npm:
     name: "{{ item }}"
     global: yes
-    state: present
+    state: latest
   with_items: "{{ nodejs_global_packages }}"
   tags: [nodejs]

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -1,42 +1,20 @@
-# Check if Node.js is installed or not and if it should be updated or not
-#
-- name: Check if Node.js is installed
-  command: node --version warn=no
-  register: nodejs_is_installed_test
-  ignore_errors: yes
-  changed_when: false
-  tags: [nodejs]
-
-- set_fact:
-    nodejs_is_installed: true
-  when: nodejs_is_installed_test.rc != 2
-  tags: [nodejs]
-
-- set_fact:
-    nodejs_is_installed: false
-    nodejs_install_new_version: true
-  when: nodejs_is_installed_test.rc == 2
-  tags: [nodejs]
-
-- set_fact:
-    nodejs_install_new_version: true
-  when: ( nodejs_is_installed == true ) and ( nodejs_is_installed_test.stdout | replace('v','') != nodejs_version )
-  tags: [nodejs]
-
-- set_fact:
-    nodejs_install_new_version: false
-  when: ( nodejs_is_installed == true ) and ( nodejs_is_installed_test.stdout | replace('v','') == nodejs_version )
-  tags: [nodejs]
-
-
-
 # Install/Update Node.js to desired version
 # These tasks will be executed when
-#  1. Node.js is not installed
+#  1. Node.js is not installed from within this role
 #  2. Node.js is installed but not in desired version
 #
-- include: install.yml
-  when: "nodejs_install_new_version == true"
+- name: Check if Node.js is installed in required version
+  shell: "node --version 2>&1 | cut -c2-"
+  args:
+    warn: no
+  ignore_errors: yes
+  changed_when: false
+  register: nodejs_version_test
+  tags: [nodejs]
+
+- include_tasks: install.yml
+  when: "nodejs_version_test.stdout != nodejs_version"
+  tags: [nodejs]
 
 
 

--- a/roles/nodejs/tasks/main.yml
+++ b/roles/nodejs/tasks/main.yml
@@ -18,7 +18,7 @@
 
 
 
-# Install global NPM packages like gulp, grunt etc
+# Install global NPM packages like gulp, grunt, forever, pm2 etc
 #
 - name: Install global NPM packages
   npm:

--- a/roles/nodejs/templates/nodesource-el7.repo.j2
+++ b/roles/nodejs/templates/nodesource-el7.repo.j2
@@ -1,7 +1,0 @@
-[nodesource]
-name=Node.js Packages for Enterprise Linux 7 - $basearch
-baseurl=https://rpm.nodesource.com/pub_8.x/el/7/$basearch
-failovermethod=priority
-enabled=1
-gpgcheck=1
-gpgkey=https://rpm.nodesource.com/pub/el/NODESOURCE-GPG-SIGNING-KEY-EL

--- a/roles/nodejs/templates/nodesource-el8.repo.j2
+++ b/roles/nodejs/templates/nodesource-el8.repo.j2
@@ -1,0 +1,7 @@
+[nodesource]
+name=Node.js Packages for Enterprise Linux 8 - $basearch
+baseurl=https://rpm.nodesource.com/pub_15.x/el/8/$basearch
+failovermethod=priority
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/NODESOURCE-GPG-SIGNING-KEY-EL

--- a/roles/openssl/defaults/main.yml
+++ b/roles/openssl/defaults/main.yml
@@ -1,5 +1,5 @@
 # Version of OpenSSL that should be installed
-openssl_version: "1.1.1g"
+openssl_version: "1.1.1i"
 
 # Path where OpenSSL will be installed. NO trailing slash at the end!
 openssl_install_path: /usr/local/openssl

--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -1,5 +1,5 @@
 # Version of PHP to install
-php_version: "7.4.7"
+php_version: "8.0.2"
 
 # Location for PHP installation
 php_install_path: /usr/local/php

--- a/roles/php/handlers/main.yml
+++ b/roles/php/handlers/main.yml
@@ -2,3 +2,4 @@
   service:
     name: php-fpm
     state: restarted
+  tags: [local]

--- a/roles/php/tasks/composer.yml
+++ b/roles/php/tasks/composer.yml
@@ -16,4 +16,4 @@
     name: composer update
     special_time: weekly
     job: "{{ php_install_path }}/bin/php /usr/local/bin/composer self-update"
-  tags: [php]
+  tags: [php, local]

--- a/roles/php/tasks/composer.yml
+++ b/roles/php/tasks/composer.yml
@@ -15,5 +15,5 @@
   cron:
     name: composer update
     special_time: weekly
-    job: "{{ php_install_path }}/bin/php /usr/local/bin/composer self-update"
+    job: "{{ php_install_path }}/bin/php /usr/local/bin/composer self-update --2"
   tags: [php, local]

--- a/roles/php/tasks/install.yml
+++ b/roles/php/tasks/install.yml
@@ -4,7 +4,7 @@
   dnf:
     name: [autoconf, gcc, gcc-c++, bison, re2c, libxml2-devel, openssl-devel, bzip2-devel, libcurl-devel, libpng-devel, libwebp-devel, libjpeg-turbo-devel, libicu-devel, oniguruma-devel, freetype-devel, libzip-devel]
     state: latest
-    enablerepo: PowerTools
+    enablerepo: powertools
   tags: [php]
 
 

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -34,4 +34,4 @@
     name: php-fpm
     state: started
     enabled: yes
-  tags: [php, healthcheck]
+  tags: [php, healthcheck, local]

--- a/roles/redis/defaults/main.yml
+++ b/roles/redis/defaults/main.yml
@@ -1,5 +1,5 @@
 # Redis version to be installed
-redis_version: "6.0.6"
+redis_version: "6.0.10"
 
 # Location where redis should be installed
 redis_install_path: /usr/local/redis

--- a/roles/redis/handlers/main.yml
+++ b/roles/redis/handlers/main.yml
@@ -2,3 +2,4 @@
   service:
     name: redis
     state: restarted
+  tags: [local]

--- a/roles/redis/tasks/configure.yml
+++ b/roles/redis/tasks/configure.yml
@@ -92,4 +92,4 @@
     state: started
     enabled: yes
   when: "redis_disable_transparent_huge_pages == true"
-  tags: [redis]
+  tags: [redis, local]

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -31,4 +31,4 @@
     name: redis
     state: started
     enabled: yes
-  tags: [redis]
+  tags: [redis, local]


### PR DESCRIPTION
- Fixes bug with duplicated values in the list of packages left to update in dnf role
- Adds special `local` tag which allows skipping certain tasks in local environments without systemd, for instance in WSL
- Update OpenSSL to 1.1.1i
- Update Git to 2.30.1
- Update nginx to 1.19.6
- Update PHP to 8.0.2
- Update composer to version 2
- Update MySQL to 8.0.23
- Update AWS CLI to 2.1.25
- Update Redis to 6.0.10
- Rewrite NodeJs role and update nodejs version to 15.9.0
- Use new naming of repositories in the latest version of CentOS