### PR TITLE
Bump version of packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,23 +50,23 @@ Included roles
 
 **ntp** - Takes care of system timezone and NTP server. It uses Chrony for using NTP.
 
-**openssl** - Compile OpenSSL from source (1.1.1i)
+**openssl** - Compile OpenSSL from source (1.1.1k)
 
-**git** - Compile and install Git from source (2.30.1) 
+**git** - Compile and install Git from source (2.33.0) 
 
-**nginx** - Compile, install and configure nginx from source (1.19.6)
+**nginx** - Compile, install and configure nginx from source (1.21.1)
 
-**php** - Compile, install and configure PHP and tools (8.0.2)
+**php** - Compile, install and configure PHP and tools (8.0.9)
 
 **firewalld** - Setup firewalld as base firewall
 
-**mysql** - Install and configure MySQL community server (8.0.23). Create databases and users. Install MySQLTuner and setup backups.
+**mysql** - Install and configure MySQL community server (8.0.26). Create databases and users. Install MySQLTuner and setup backups.
 
-**awscli** - Install and configure AWS CLI command line tool (2.1.25)
+**awscli** - Install and configure AWS CLI command line tool (2.2.31)
 
-**redis** - Install and configure Redis with TLS support (6.0.10)
+**redis** - Install and configure Redis with TLS support (6.2.5)
 
-**nodejs** - Install Node.js and NPM (15.9.0)
+**nodejs** - Install Node.js and NPM (16.7.0)
 
 **centos** - Takes care of system settings. Set up firewall based on iptables. Disable Transparent Huge Pages.
 You can setup logrotate scripts with this role as well.

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -3,13 +3,13 @@ Current Versions
 
 Each package have it's own release cycle. Here is the list of URLs that we check for new versions:
 
-* [CentOS](https://wiki.centos.org/Manuals/ReleaseNotes) 8.3.2011
-* [OpenSSL](https://github.com/openssl/openssl/releases) 1.1.1i
-* [Git](https://github.com/git/git/releases) 2.30.1
-* [nginx](https://nginx.org/en/download.html) 1.19.6
-* [PHP](https://github.com/php/php-src/releases) 8.0.2
-* [MySQL](https://dev.mysql.com/downloads/mysql/) 8.0.23
-* [AWS CLI](https://github.com/aws/aws-cli/releases) 2.1.25
-* [Redis](https://redis.io/download) 6.0.10
-* [NodeJs](https://nodejs.org/en/) 15.9.0
+* [CentOS](https://wiki.centos.org/Manuals/ReleaseNotes) 8.4.2105
+* [OpenSSL](https://github.com/openssl/openssl/releases) 1.1.1k
+* [Git](https://github.com/git/git/releases) 2.33.0
+* [nginx](https://nginx.org/en/download.html) 1.21.1
+* [PHP](https://github.com/php/php-src/releases) 8.0.9
+* [MySQL](https://dev.mysql.com/downloads/mysql/) 8.0.26
+* [AWS CLI](https://github.com/aws/aws-cli/releases) 2.2.31
+* [Redis](https://redis.io/download) 6.2.5
+* [NodeJs](https://nodejs.org/en/) 16.7.0
 * [HTTPD](https://github.com/apache/httpd/releases) 2.4.33

--- a/roles/awscli/defaults/main.yml
+++ b/roles/awscli/defaults/main.yml
@@ -1,5 +1,5 @@
 # Version of AWS CLI to install
-awscli_version: 2.1.25
+awscli_version: 2.2.31
 
 # Where to download AWS CLI zip file
 awscli_zip_file_location: /usr/src

--- a/roles/firewalld/defaults/main.yml
+++ b/roles/firewalld/defaults/main.yml
@@ -10,6 +10,9 @@ firewalld_all_incoming_traffic_services:
 # List of services that should be available from whitelisted IP addresses
 firewalld_internal_zone_services: []
 
+# List of all ports that should be available from whitelisted IP addresses
+firewalld_internal_zone_ports: []
+
 # List of IP addresses that should have access to given services
 firewalld_internal_zone_sources: []
 

--- a/roles/firewalld/tasks/main.yml
+++ b/roles/firewalld/tasks/main.yml
@@ -103,7 +103,7 @@
 
 
 # Internal zone is good candidate to allow traffic only from whitelisted IP addresses
-# This part specifies list of available services and sources (IP addresses) that will have access to them
+# This part specifies list of available services or ports and sources (IP addresses) that will have access to them
 #
 - name: Add services that can be accessed from whitelisted IP addresses to internal zone
   firewalld:
@@ -134,6 +134,38 @@
     state: disabled
     zone: internal
   loop: "{{ firewalld_internal_zone_enabled_services | difference(firewalld_internal_zone_services) }}"
+  notify: reload firewalld
+  tags: [firewalld]
+
+- name: Add ports that can be accessed from whitelisted IP addresses to internal zone
+  firewalld:
+    immediate: yes
+    permanent: yes
+    port: "{{ item }}"
+    state: enabled
+    zone: internal
+  loop: "{{ firewalld_internal_zone_ports }}"
+  notify: reload firewalld
+  tags: [firewalld]
+
+- name: Get all enabled ports for internal zone
+  shell: "/usr/bin/firewall-cmd --zone=internal --list-ports"
+  register: firewalld_internal_zone_ports_result
+  changed_when: false
+  tags: [firewalld]
+
+- set_fact:
+    firewalld_internal_zone_enabled_ports: "{{ firewalld_internal_zone_ports_result.stdout.split() }}"
+  tags: [firewalld]
+
+- name: Remove unused ports from internal zone
+  firewalld:
+    immediate: yes
+    permanent: yes
+    port: "{{ item }}"
+    state: disabled
+    zone: internal
+  loop: "{{ firewalld_internal_zone_enabled_ports | difference(firewalld_internal_zone_ports) }}"
   notify: reload firewalld
   tags: [firewalld]
 

--- a/roles/git/defaults/main.yml
+++ b/roles/git/defaults/main.yml
@@ -1,5 +1,5 @@
 # Version of git that should be installed
-git_version: "2.30.1"
+git_version: "2.33.0"
 
 # Location where Git should be installed
 git_install_path: /usr/local/git

--- a/roles/mysql/defaults/main.yml
+++ b/roles/mysql/defaults/main.yml
@@ -1,5 +1,5 @@
 # Version of MySQL that should be installed
-mysql_version: "8.0.23"
+mysql_version: "8.0.26"
 
 # MySQL root password
 mysql_root_password: "rKp#rX3EP?Y2JGug*q,s>F,)@Hbuf9KCH#Z8odF44!)vH7MmrwJ4"

--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -1,5 +1,5 @@
 # Version of nginx that should be installed
-nginx_version: "1.19.6"
+nginx_version: "1.21.1"
 
 # Path where nginx will be installed. NO trailing slash at the end!
 nginx_install_path: /usr/local/nginx
@@ -14,10 +14,10 @@ nginx_build_user: developer
 nginx_build_group: developer
 
 # Version of PCRE that will be compiled with nginx
-nginx_pcre_version: "8.44"
+nginx_pcre_version: "8.45"
 
 # Version of OpenSSL that will be compiled with nginx
-nginx_openssl_version: "1.1.1i"
+nginx_openssl_version: "1.1.1k"
 
 # Version of Zlib that will be compiled with nginx
 nginx_zlib_version: "1.2.11"

--- a/roles/nodejs/defaults/main.yml
+++ b/roles/nodejs/defaults/main.yml
@@ -1,5 +1,5 @@
 # Node.js version
-nodejs_version: "15.9.0"
+nodejs_version: "16.7.0"
 
 # Global packages (list of packages installed with -g option)
 nodejs_global_packages: []

--- a/roles/nodejs/templates/nodesource-el8.repo.j2
+++ b/roles/nodejs/templates/nodesource-el8.repo.j2
@@ -1,6 +1,6 @@
 [nodesource]
 name=Node.js Packages for Enterprise Linux 8 - $basearch
-baseurl=https://rpm.nodesource.com/pub_15.x/el/8/$basearch
+baseurl=https://rpm.nodesource.com/pub_16.x/el/8/$basearch
 failovermethod=priority
 enabled=1
 gpgcheck=1

--- a/roles/openssl/defaults/main.yml
+++ b/roles/openssl/defaults/main.yml
@@ -1,5 +1,5 @@
 # Version of OpenSSL that should be installed
-openssl_version: "1.1.1i"
+openssl_version: "1.1.1k"
 
 # Path where OpenSSL will be installed. NO trailing slash at the end!
 openssl_install_path: /usr/local/openssl

--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -1,5 +1,5 @@
 # Version of PHP to install
-php_version: "8.0.2"
+php_version: "8.0.9"
 
 # Location for PHP installation
 php_install_path: /usr/local/php

--- a/roles/redis/defaults/main.yml
+++ b/roles/redis/defaults/main.yml
@@ -1,5 +1,5 @@
 # Redis version to be installed
-redis_version: "6.0.10"
+redis_version: "6.2.5"
 
 # Location where redis should be installed
 redis_install_path: /usr/local/redis


### PR DESCRIPTION
Update OpenSSL to 1.1.1k
Update GIT to 2.33.0
Update nginx to 1.21.1 (included OpenSSL version to 1.1.1k and PCRE to 8.45)
Update PHP to 8.0.9
New option to add ports alongside the services to the internal zone
Update MySQL to 8.0.26
Update AWS CLI to 2.2.31
Update Redis to 6.2.5
Update NodeJS to 16.7.0