### PR TITLE
Support rocky linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ playbooks/*
 !playbooks/example-playbook.yml
 vars/*.yml
 !vars/example-vars.yml
+.idea

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Included roles
 
 **nginx** - Compile, install and configure [nginx](https://nginx.org/en/download.html) from source (1.23.2)
 
-**php** - Compile, install and configure [PHP](https://github.com/php/php-src/tags) and tools (8.0.14)
+**php** - Compile, install and configure [PHP](https://github.com/php/php-src/tags) and tools (8.1.12)
 
 **firewalld** - Setup firewalld as base firewall
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Included roles
 
 **openssl** - Compile [OpenSSL](https://github.com/openssl/openssl/tags) from source (3.0.1)
 
-**git** - Compile and install [Git](https://github.com/git/git/tags) from source (2.38.1) 
+**git** - Compile and install [Git](https://github.com/git/git/tags) from source (2.39.1) 
 
 **nginx** - Compile, install and configure [nginx](https://nginx.org/en/download.html) from source (1.23.2)
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Included roles
 
 **redis** - Install and configure [Redis](https://redis.io/download) with TLS support (7.0.8)
 
-**nodejs** - Install [NodeJs](https://nodejs.org/en/) and NPM (19.0.0)
+**nodejs** - Install [NodeJs](https://nodejs.org/en/) and NPM (19.6.0)
 
 **centos** - Takes care of system settings. Set up firewall based on iptables. Disable Transparent Huge Pages.
 You can setup logrotate scripts with this role as well.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Included roles
 
 **openssl** - Compile [OpenSSL](https://github.com/openssl/openssl/tags) from source (3.0.1)
 
-**git** - Compile and install [Git](https://github.com/git/git/tags) from source (2.34.1) 
+**git** - Compile and install [Git](https://github.com/git/git/tags) from source (2.38.1) 
 
 **nginx** - Compile, install and configure [nginx](https://nginx.org/en/download.html) from source (1.21.5)
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Included roles
 
 **firewalld** - Setup firewalld as base firewall
 
-**mysql** - Install and configure [MySQL](https://dev.mysql.com/downloads/mysql/) community server (8.0.27). Create databases and users. Install MySQLTuner and set up backups.
+**mysql** - Install and configure [MySQL](https://dev.mysql.com/downloads/mysql/) community server (8.0.31). Create databases and users. Install MySQLTuner and set up backups.
 
 **awscli** - Install and configure [AWS CLI](https://github.com/aws/aws-cli/tags) command line tool (2.8.7)
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Included roles
 
 **git** - Compile and install [Git](https://github.com/git/git/tags) from source (2.39.1) 
 
-**nginx** - Compile, install and configure [nginx](https://nginx.org/en/download.html) from source (1.23.2)
+**nginx** - Compile, install and configure [nginx](https://nginx.org/en/download.html) from source (1.23.3)
 
 **php** - Compile, install and configure [PHP](https://github.com/php/php-src/tags) and tools (8.1.12)
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Included roles
 
 **awscli** - Install and configure [AWS CLI](https://github.com/aws/aws-cli/tags) command line tool (2.8.7)
 
-**redis** - Install and configure [Redis](https://redis.io/download) with TLS support (7.0.5)
+**redis** - Install and configure [Redis](https://redis.io/download) with TLS support (7.0.8)
 
 **nodejs** - Install [NodeJs](https://nodejs.org/en/) and NPM (19.0.0)
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Included roles
 
 **nginx** - Compile, install and configure [nginx](https://nginx.org/en/download.html) from source (1.23.3)
 
-**php** - Compile, install and configure [PHP](https://github.com/php/php-src/tags) and tools (8.1.12)
+**php** - Compile, install and configure [PHP](https://github.com/php/php-src/tags) and tools (8.2.2)
 
 **firewalld** - Setup firewalld as base firewall
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ ansible-playbook -i hosts playbooks/YOUR_PLAYBOOK_FILE.yml -K
 
 Included roles
 --------------
-**dnf** - Handle [CentOS](https://wiki.centos.org/Manuals/ReleaseNotes) package management, security features, and package installation optimizations.
+**dnf** - Handle [RockyLinux](https://rockylinux.org/news/) package management, security features, and package installation optimizations.
 
 **users** - Handle users/groups management and enables sudo.
 
@@ -62,7 +62,7 @@ Included roles
 
 **mysql** - Install and configure [MySQL](https://dev.mysql.com/downloads/mysql/) community server (8.0.27). Create databases and users. Install MySQLTuner and set up backups.
 
-**awscli** - Install and configure [AWS CLI](https://github.com/aws/aws-cli/tags) command line tool (2.4.7)
+**awscli** - Install and configure [AWS CLI](https://github.com/aws/aws-cli/tags) command line tool (2.8.7)
 
 **redis** - Install and configure [Redis](https://redis.io/download) with TLS support (6.2.6)
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Included roles
 
 **awscli** - Install and configure [AWS CLI](https://github.com/aws/aws-cli/tags) command line tool (2.8.7)
 
-**redis** - Install and configure [Redis](https://redis.io/download) with TLS support (6.2.6)
+**redis** - Install and configure [Redis](https://redis.io/download) with TLS support (7.0.5)
 
 **nodejs** - Install [NodeJs](https://nodejs.org/en/) and NPM (19.0.0)
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Included roles
 
 **git** - Compile and install [Git](https://github.com/git/git/tags) from source (2.38.1) 
 
-**nginx** - Compile, install and configure [nginx](https://nginx.org/en/download.html) from source (1.21.5)
+**nginx** - Compile, install and configure [nginx](https://nginx.org/en/download.html) from source (1.23.2)
 
 **php** - Compile, install and configure [PHP](https://github.com/php/php-src/tags) and tools (8.0.14)
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Included roles
 
 **redis** - Install and configure [Redis](https://redis.io/download) with TLS support (6.2.6)
 
-**nodejs** - Install [NodeJs](https://nodejs.org/en/) and NPM (17.3.0)
+**nodejs** - Install [NodeJs](https://nodejs.org/en/) and NPM (19.0.0)
 
 **centos** - Takes care of system settings. Set up firewall based on iptables. Disable Transparent Huge Pages.
 You can setup logrotate scripts with this role as well.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Included roles
 
 **firewalld** - Setup firewalld as base firewall
 
-**mysql** - Install and configure [MySQL](https://dev.mysql.com/downloads/mysql/) community server (8.0.31). Create databases and users. Install MySQLTuner and set up backups.
+**mysql** - Install and configure [MySQL](https://dev.mysql.com/downloads/mysql/) community server (8.0.32). Create databases and users. Install MySQLTuner and set up backups.
 
 **awscli** - Install and configure [AWS CLI](https://github.com/aws/aws-cli/tags) command line tool (2.8.7)
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Included roles
 
 **mysql** - Install and configure [MySQL](https://dev.mysql.com/downloads/mysql/) community server (8.0.32). Create databases and users. Install MySQLTuner and set up backups.
 
-**awscli** - Install and configure [AWS CLI](https://github.com/aws/aws-cli/tags) command line tool (2.8.7)
+**awscli** - Install and configure [AWS CLI](https://github.com/aws/aws-cli/tags) command line tool (2.9.21)
 
 **redis** - Install and configure [Redis](https://redis.io/download) with TLS support (7.0.8)
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 LAMP on Steroids
 ================
 
-Setup your server quickly with LAMP on Steroids. This repository is dedicated to the `CentOS 7/8` system.
-The main goal is to set up a working LAMP server with the latest versions of available tools.
-The secondary goal is to keep your server secure and up to date.
+**LAMP On Steroids** contains a set of Ansible roles that help set up a modern RHEL web server. We test it out mainly on
+the `RockyLinux 9` system, but it should also work on `CentOS Stream 9` and other RHEL-based systems.
+The primary purpose is to set up a working and secure web server for PHP/Node.js applications.
 
 How to use?
 -----------

--- a/roles/awscli/defaults/main.yml
+++ b/roles/awscli/defaults/main.yml
@@ -1,5 +1,5 @@
 # Version of AWS CLI to install
-awscli_version: 2.8.7
+awscli_version: 2.9.21
 
 # Where to download AWS CLI zip file
 awscli_zip_file_location: /usr/src

--- a/roles/awscli/defaults/main.yml
+++ b/roles/awscli/defaults/main.yml
@@ -1,5 +1,5 @@
 # Version of AWS CLI to install
-awscli_version: 2.4.7
+awscli_version: 2.8.7
 
 # Where to download AWS CLI zip file
 awscli_zip_file_location: /usr/src

--- a/roles/centos/README.md
+++ b/roles/centos/README.md
@@ -1,5 +1,8 @@
-CentOS role
+CentOS role (Deprecated)
 ==========
+
+** THIS ROLE WILL BE REMOVED SOON **
+------------------------------------
 
 This role will install and configure CentOS to version 7.4
 There are multiple tasks and scenarios this role can do:

--- a/roles/datadog/README.md
+++ b/roles/datadog/README.md
@@ -1,5 +1,8 @@
-Datadog role
+Datadog role (Deprecated)
 ============
+
+** THIS ROLE WILL BE REMOVED SOON **
+------------------------------------
 
 This role will install and configure Datadog agent
 

--- a/roles/dnf/tasks/main.yml
+++ b/roles/dnf/tasks/main.yml
@@ -48,7 +48,7 @@
     name: dnf-automatic-download.timer
     state: started
     enabled: yes
-  tags: [dnf, local]
+  tags: [dnf]
 
 
 

--- a/roles/git/defaults/main.yml
+++ b/roles/git/defaults/main.yml
@@ -1,5 +1,5 @@
 # Version of git that should be installed
-git_version: "2.34.1"
+git_version: "2.38.1"
 
 # Location where Git should be installed
 git_install_path: /usr/local/git

--- a/roles/git/defaults/main.yml
+++ b/roles/git/defaults/main.yml
@@ -1,5 +1,5 @@
 # Version of git that should be installed
-git_version: "2.38.1"
+git_version: "2.39.1"
 
 # Location where Git should be installed
 git_install_path: /usr/local/git

--- a/roles/git/tasks/install.yml
+++ b/roles/git/tasks/install.yml
@@ -2,8 +2,9 @@
 #
 - name: Install required packages for compiling Git
   dnf:
-    name: [autoconf, expat-devel, gcc, gettext-devel, libcurl-devel, openssl-devel, perl-devel, zlib-devel]
+    name: [autoconf, expat-devel, gcc, gettext-devel, libcurl-devel, openssl-devel, perl-devel, zlib-devel, tar]
     state: latest
+    enablerepo: powertools
   tags: [git]
 
 

--- a/roles/httpd/README.md
+++ b/roles/httpd/README.md
@@ -1,5 +1,8 @@
-HTTPD role
+HTTPD role (Deprecated)
 ==========
+
+** THIS ROLE WILL BE REMOVED SOON **
+------------------------------------
 
 This role will install Apache httpd https://httpd.apache.org/ server on CentOS.
 Apache httpd will be installed in 2.4.33 version and will be compiled from source.

--- a/roles/mysql/defaults/main.yml
+++ b/roles/mysql/defaults/main.yml
@@ -1,5 +1,5 @@
 # Version of MySQL that should be installed
-mysql_version: "8.0.27"
+mysql_version: "8.0.31"
 
 # MySQL root password
 mysql_root_password: "rKp#rX3EP?Y2JGug*q,s>F,)@Hbuf9KCH#Z8odF44!)vH7MmrwJ4"

--- a/roles/mysql/defaults/main.yml
+++ b/roles/mysql/defaults/main.yml
@@ -1,5 +1,5 @@
 # Version of MySQL that should be installed
-mysql_version: "8.0.31"
+mysql_version: "8.0.32"
 
 # MySQL root password
 mysql_root_password: "rKp#rX3EP?Y2JGug*q,s>F,)@Hbuf9KCH#Z8odF44!)vH7MmrwJ4"

--- a/roles/mysql/handlers/main.yml
+++ b/roles/mysql/handlers/main.yml
@@ -2,4 +2,3 @@
   service:
     name: mysqld
     state: restarted
-  tags: [local]

--- a/roles/mysql/tasks/backup.yml
+++ b/roles/mysql/tasks/backup.yml
@@ -17,6 +17,7 @@
     host: "{{ mysql_root_host }}"
     state: present
     priv: "{{ mysql_backup_databases | map(attribute='key') |  map('regex_replace', '(.*)', '\\1.*:SELECT') | list | join('/') }}"
+    login_host: "{{ mysql_root_host }}"
   no_log: true
   when: "mysql_backup_databases is defined"
   tags: [mysql]
@@ -62,4 +63,4 @@
     job: "bash {{ item.value.backup_directory }}/{{ item.key }}-backup.sh >> {{ item.value.backup_directory }}/{{ item.key }}-backup.log 2>&1"
   with_items: "{{ mysql_backup_databases }}"
   when: "mysql_backup_databases is defined"
-  tags: [mysql, local]
+  tags: [mysql]

--- a/roles/mysql/tasks/databases.yml
+++ b/roles/mysql/tasks/databases.yml
@@ -4,6 +4,7 @@
   mysql_db:
     name: "{{ item.key }}"
     state: present
+    login_host: "{{ mysql_root_host }}"
   with_dict: "{{ mysql_databases }}"
   tags: [mysql]
 
@@ -13,6 +14,7 @@
     password: "{{ item.value.password }}"
     host: "{{ item.value.host }}"
     priv: "{{ item.key }}.*:ALL"
+    login_host: "{{ mysql_root_host }}"
   with_dict: "{{ mysql_databases }}"
   no_log: yes
   tags: [mysql]

--- a/roles/mysql/tasks/install.yml
+++ b/roles/mysql/tasks/install.yml
@@ -6,10 +6,17 @@
     state: present
   tags: [mysql]
 
+- name: Download RPM package
+  shell: curl -O -L https://dev.mysql.com/get/mysql80-community-release-el9-1.noarch.rpm
+  args:
+    chdir: /usr/src
+    creates: /usr/src/mysql80-community-release-el9-1.noarch.rpm
+  tags: [mysql]
+
 - name: Install MySQL RPM
-  dnf:
-    name: "https://dev.mysql.com/get/mysql80-community-release-el9-1.noarch.rpm"
-    state: latest
+  yum:
+    name: /usr/src/mysql80-community-release-el9-1.noarch.rpm
+    state: present
   tags: [mysql]
 
 

--- a/roles/mysql/tasks/install.yml
+++ b/roles/mysql/tasks/install.yml
@@ -1,8 +1,14 @@
 # Install MySQL RPM from remote repository
 #
+- name: Import RPM key
+  rpm_key:
+    key: https://repo.mysql.com/RPM-GPG-KEY-mysql-2022
+    state: present
+  tags: [mysql]
+
 - name: Install MySQL RPM
   dnf:
-    name: "https://dev.mysql.com/get/mysql80-community-release-el8-1.noarch.rpm"
+    name: "https://dev.mysql.com/get/mysql80-community-release-el9-1.noarch.rpm"
     state: latest
   tags: [mysql]
 

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -2,16 +2,17 @@
 # This task will be executed if MySQL is not installed or it's installed in different version
 #
 - name: Check if MySQL is installed in required version
-  shell: mysql --version | awk '{print $3}'
+  shell: mysqld --version | awk '{print $3}'
   args:
     warn: no
   ignore_errors: yes
   changed_when: false
   register: mysql_version_test
-  tags: [mysql]
+  tags: [ mysql ]
 
-- include: install.yml
+- include_tasks: install.yml
   when: "mysql_version_test.stdout != mysql_version"
+  tags: [ mysql ]
 
 
 
@@ -22,7 +23,7 @@
     name: mysqld
     state: started
     enabled: yes
-  tags: [mysql, local]
+  tags: [ mysql ]
 
 
 

--- a/roles/mysql/tasks/root-password.yml
+++ b/roles/mysql/tasks/root-password.yml
@@ -2,7 +2,7 @@
 #
 - name: Install python38-PyMySQL for Ansible
   dnf:
-    name: [python38, python38-PyMySQL]
+    name: [python3, python3-PyMySQL]
     state: latest
   tags: [mysql]
 

--- a/roles/mysql/tasks/root-password.yml
+++ b/roles/mysql/tasks/root-password.yml
@@ -36,9 +36,10 @@
 - name: Check if current MySQL root password is valid
   mysql_info:
     filter: version
+    login_host: "{{ mysql_root_host }}"
   ignore_errors: yes
   register: mysql_root_password_test
-  tags: [mysql, local]
+  tags: [mysql]
 
 - name: Create init file with new root password
   template:
@@ -48,34 +49,34 @@
     group: mysql
     mode: 0644
   when: "mysql_root_password_test.failed"
-  tags: [mysql, local]
+  tags: [mysql]
 
 - name: Stop MySQL server
   service:
     name: mysqld
     state: stopped
   when: "mysql_root_password_test.failed"
-  tags: [mysql, local]
+  tags: [mysql]
 
 - name: Start MySQL server with init file
   shell: /usr/sbin/mysqld --init-file=/tmp/mysql-init-file  --user=mysql &
   when: "mysql_root_password_test.failed"
-  tags: [mysql, local]
+  tags: [mysql]
 
 - name: Remove init file
   file:
     path: /tmp/mysql-init-file
     state: absent
-  tags: [mysql, local]
+  tags: [mysql]
 
 - name: Kill server with init file
   shell: kill `ps aux | grep /usr/sbin/mysqld | grep -v grep | awk '{print $2}'`
   when: "mysql_root_password_test.failed"
-  tags: [mysql, local]
+  tags: [mysql]
 
 - name: Start MySQL server
   service:
     name: mysqld
     state: started
   when: "mysql_root_password_test.failed"
-  tags: [mysql, local]
+  tags: [mysql]

--- a/roles/nginx/README.md
+++ b/roles/nginx/README.md
@@ -19,11 +19,11 @@ Here is the list of configurable variables for this role:
  
  - `nginx_build_group` group of the user for the build process. By default it's `developer`.
 
- - `nginx_pcre2_version` version of PCRE2 to download and compile with nginx. It will not override PCRE binaries on CentOS.
+ - `nginx_pcre2_version` version of PCRE2 to download and compile with nginx. It will not override PCRE binaries on RockyLinux.
  
- - `nginx_openssl_version` version of OpenSSL to download and compile with nginx. It will not override OpenSSL binaries on CentOS.
+ - `nginx_openssl_version` version of OpenSSL to download and compile with nginx. It will not override OpenSSL binaries on RockyLinux.
  
- - `nginx_zlib_version` version of Zlib to download and compile with nginx. It will not override Zlib binaries on CentOS.
+ - `nginx_zlib_version` version of Zlib to download and compile with nginx. It will not override Zlib binaries on RockyLinux.
  
  - `nginx_configure_options` list of arguments for `./configure` command.
  

--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -1,5 +1,5 @@
 # Version of nginx that should be installed
-nginx_version: "1.21.5"
+nginx_version: "1.23.2"
 
 # Path where nginx will be installed. NO trailing slash at the end!
 nginx_install_path: /usr/local/nginx
@@ -14,13 +14,13 @@ nginx_build_user: developer
 nginx_build_group: developer
 
 # Version of PCRE2 that will be compiled with nginx
-nginx_pcre2_version: "10.39"
+nginx_pcre2_version: "10.40"
 
 # Version of OpenSSL that will be compiled with nginx
-nginx_openssl_version: "3.0.1"
+nginx_openssl_version: "3.0.7"
 
 # Version of Zlib that will be compiled with nginx
-nginx_zlib_version: "1.2.11"
+nginx_zlib_version: "1.2.13"
 
 # List of configuration options for nginx
 nginx_configure_options:

--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -1,5 +1,5 @@
 # Version of nginx that should be installed
-nginx_version: "1.23.2"
+nginx_version: "1.23.3"
 
 # Path where nginx will be installed. NO trailing slash at the end!
 nginx_install_path: /usr/local/nginx
@@ -14,7 +14,7 @@ nginx_build_user: developer
 nginx_build_group: developer
 
 # Version of PCRE2 that will be compiled with nginx
-nginx_pcre2_version: "10.40"
+nginx_pcre2_version: "10.42"
 
 # Version of OpenSSL that will be compiled with nginx
 nginx_openssl_version: "3.0.7"

--- a/roles/nginx/tasks/install.yml
+++ b/roles/nginx/tasks/install.yml
@@ -2,7 +2,7 @@
 #
 - name: Install required packages for compiling nginx
   dnf:
-    name: [gcc, gcc-c++, git]
+    name: [gcc, gcc-c++, git, perl-FindBin, perl-IPC-Cmd]
     state: latest
   tags: [nginx]
 

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -31,4 +31,4 @@
     name: nginx
     state: started
     enabled: yes
-  tags: [nginx, healthcheck, local]
+  tags: [nginx, healthcheck]

--- a/roles/nodejs/defaults/main.yml
+++ b/roles/nodejs/defaults/main.yml
@@ -1,5 +1,5 @@
 # Node.js version
-nodejs_version: "17.3.0"
+nodejs_version: "19.0.0"
 
 # Global packages (list of packages installed with -g option)
 nodejs_global_packages: []

--- a/roles/nodejs/defaults/main.yml
+++ b/roles/nodejs/defaults/main.yml
@@ -1,5 +1,5 @@
 # Node.js version
-nodejs_version: "19.0.0"
+nodejs_version: "19.6.0"
 
 # Global packages (list of packages installed with -g option)
 nodejs_global_packages: []

--- a/roles/nodejs/tasks/install.yml
+++ b/roles/nodejs/tasks/install.yml
@@ -2,8 +2,8 @@
 #
 - name: Make sure that Node.js repository is available
   template:
-    src: nodesource-el8.repo.j2
-    dest: /etc/yum.repos.d/nodesource-el8.repo
+    src: nodesource-el9.repo.j2
+    dest: /etc/yum.repos.d/nodesource-el9.repo
     owner: root
     group: root
     mode: 0644

--- a/roles/nodejs/templates/nodesource-el9.repo.j2
+++ b/roles/nodejs/templates/nodesource-el9.repo.j2
@@ -1,6 +1,6 @@
 [nodesource]
-name=Node.js Packages for Enterprise Linux 8 - $basearch
-baseurl=https://rpm.nodesource.com/pub_17.x/el/8/$basearch
+name=Node.js Packages for Enterprise Linux 9 - $basearch
+baseurl=https://rpm.nodesource.com/pub_19.x/el/9/$basearch
 failovermethod=priority
 enabled=1
 gpgcheck=1

--- a/roles/openssl/README.md
+++ b/roles/openssl/README.md
@@ -1,4 +1,4 @@
-OpenSSL role
+OpenSSL role (Deprecated)
 ============
 
 This role will compile OpenSSL from source on CentOS 8 server.

--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -1,5 +1,5 @@
 # Version of PHP to install
-php_version: "8.1.12"
+php_version: "8.2.2"
 
 # Location for PHP installation
 php_install_path: /usr/local/php

--- a/roles/php/defaults/main.yml
+++ b/roles/php/defaults/main.yml
@@ -1,5 +1,5 @@
 # Version of PHP to install
-php_version: "8.0.14"
+php_version: "8.1.12"
 
 # Location for PHP installation
 php_install_path: /usr/local/php

--- a/roles/php/handlers/main.yml
+++ b/roles/php/handlers/main.yml
@@ -2,4 +2,3 @@
   service:
     name: php-fpm
     state: restarted
-  tags: [local]

--- a/roles/php/tasks/composer.yml
+++ b/roles/php/tasks/composer.yml
@@ -16,4 +16,4 @@
     name: composer update
     special_time: weekly
     job: "{{ php_install_path }}/bin/php /usr/local/bin/composer self-update --2"
-  tags: [php, local]
+  tags: [php]

--- a/roles/php/tasks/extensions.yml
+++ b/roles/php/tasks/extensions.yml
@@ -1,10 +1,22 @@
 # Install PECL extensions
+# If the server is already configured and PHP is upgraded to next version, from instance 8.1 -> 8.2, extensions must be reinstalled to avoid configuration errors:
+# Remove extensions first and install them back in
 #
+- name: Remove old PECL extensions
+  shell: "{{ php_install_path }}/bin/pecl uninstall {{ item }}"
+  with_items: "{{ php_extensions }}"
+  tags: [php]
+
 - name: Install PECL extensions
   shell: "no | {{ php_install_path }}/bin/pecl upgrade {{ item }}"
   with_items: "{{ php_extensions }}"
   register: php_extensions_upgrade
   changed_when: "php_extensions_upgrade.stdout != 'Nothing to upgrade'"
+  tags: [php]
+
+- name: Remove old Zend extensions
+  shell: "{{ php_install_path }}/bin/pecl uninstall {{ item }}"
+  with_items: "{{ php_zend_extensions }}"
   tags: [php]
 
 - name: Install Zend extensions

--- a/roles/php/tasks/install.yml
+++ b/roles/php/tasks/install.yml
@@ -1,10 +1,17 @@
 # Install required packages for compiling PHP from source
 #
+- name: Install epel-release
+  dnf:
+    name: epel-release
+    state: latest
+  tags: [php]
+
 - name: Install required packages for compiling PHP
   dnf:
     name: [autoconf, gcc, gcc-c++, bison, re2c, libxml2-devel, openssl-devel, bzip2-devel, libcurl-devel, libpng-devel, libwebp-devel, libjpeg-turbo-devel, libicu-devel, oniguruma-devel, freetype-devel, libzip-devel]
     state: latest
     enablerepo: crb
+    update_cache: true
   tags: [php]
 
 

--- a/roles/php/tasks/install.yml
+++ b/roles/php/tasks/install.yml
@@ -4,7 +4,7 @@
   dnf:
     name: [autoconf, gcc, gcc-c++, bison, re2c, libxml2-devel, openssl-devel, bzip2-devel, libcurl-devel, libpng-devel, libwebp-devel, libjpeg-turbo-devel, libicu-devel, oniguruma-devel, freetype-devel, libzip-devel]
     state: latest
-    enablerepo: powertools
+    enablerepo: crb
   tags: [php]
 
 

--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -34,4 +34,4 @@
     name: php-fpm
     state: started
     enabled: yes
-  tags: [php, healthcheck, local]
+  tags: [php, healthcheck]

--- a/roles/redis/defaults/main.yml
+++ b/roles/redis/defaults/main.yml
@@ -1,5 +1,5 @@
 # Redis version to be installed
-redis_version: "6.2.6"
+redis_version: "7.0.5"
 
 # Location where redis should be installed
 redis_install_path: /usr/local/redis

--- a/roles/redis/defaults/main.yml
+++ b/roles/redis/defaults/main.yml
@@ -1,5 +1,5 @@
 # Redis version to be installed
-redis_version: "7.0.5"
+redis_version: "7.0.8"
 
 # Location where redis should be installed
 redis_install_path: /usr/local/redis
@@ -31,7 +31,7 @@ redis_default_configuration:
   supervised: "systemd"
   loglevel: "notice"
   logfile: "{{ redis_logs_dir }}/redis.log"
-  requirepass: "a-rgU!Uf3H}ktBiizEVKA]yM^qDCUW3Un#iL_3A&tpUx=>Zk"
+  requirepass: "a-rgU!Uf3H}ktBiizEVKA]yM^qDCUW3UniL_3A&tpUx=>Zk"
   dir: "{{ redis_database_dir }}"
   tls-cert-file: "{{ redis_install_path }}/tls/redis.crt"
   tls-key-file: "{{ redis_install_path }}/tls/redis.key"

--- a/roles/redis/handlers/main.yml
+++ b/roles/redis/handlers/main.yml
@@ -2,4 +2,3 @@
   service:
     name: redis
     state: restarted
-  tags: [local]

--- a/roles/redis/tasks/configure.yml
+++ b/roles/redis/tasks/configure.yml
@@ -92,4 +92,4 @@
     state: started
     enabled: yes
   when: "redis_disable_transparent_huge_pages == true"
-  tags: [redis, local]
+  tags: [redis]

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -31,4 +31,4 @@
     name: redis
     state: started
     enabled: yes
-  tags: [redis, local]
+  tags: [redis]

--- a/roles/ssh/README.md
+++ b/roles/ssh/README.md
@@ -1,15 +1,20 @@
 SSH role
 ==========
 
-This role hardens SSHD config.
+This role hardens the SSHD config.
 
 
 Variables
 ---------
 Here is the list of configurable variables for this role:
 
- - `ssh_sshd_default_config_options` this is the list of key and values to be set in `/etc/ssh/sshd_config` config file. You should not change it directly. Instead please set `ssh_sshd_user_config_options` variable. 
- 
- - `ssh_sshd_user_config_options` by default it's empty. You can add additional options to be set in `/etc/ssh/sshd_config` file or override the values from `ssh_sshd_default_config_options` variable. These two vars will be combined into single variable. 
+- `ssh_sshd_default_config_options` is the list of keys and values to be set in the `/etc/ssh/sshd_config.d/` config
+  file. It would be best if you did not change it directly. Instead, please put your config in
+  the `ssh_sshd_user_config_options` variable.
 
- - `ssh_sshd_host_keys` list of enabled HostKeys in `/etc/ssh/sshd_config` config file. All other keys not specified here will be removed from config file.oved but it is necessary for Ansible purposes.
+- `ssh_sshd_user_config_options` by default it's empty. You can add additional options to be set
+  in the `/etc/ssh/sshd_config.d` file or override the values from the `ssh_sshd_default_config_options` variable.
+  Ansible will combine these two vars into a single variable.
+
+- `ssh_sshd_host_keys` list of enabled HostKeys in the `/etc/ssh/sshd_config` config file. Ansible will remove all other
+  keys not specified here from the config file.

--- a/roles/ssh/defaults/main.yml
+++ b/roles/ssh/defaults/main.yml
@@ -1,8 +1,7 @@
-# List of default secure config options for /etc/ssh/sshd_config file
+# List of default secure config options for /etc/ssh/sshd_config.d file
 ssh_sshd_default_config_options:
   PubkeyAuthentication: "yes"
   PasswordAuthentication : "no"
-  ChallengeResponseAuthentication: "no"
   GSSAPIAuthentication: "no"
   KerberosAuthentication: "no"
   PermitRootLogin: "no"
@@ -17,7 +16,7 @@ ssh_sshd_default_config_options:
   Ciphers: "chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr"
   MACs: "hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com"
 
-# Custom user settings to be applied to /etc/ssh/sshd_config file. Please refer to README.md in this role
+# Custom user settings to be applied to /etc/ssh/sshd_config.d file. Please refer to README.md in this role
 ssh_sshd_user_config_options: []
 
 # List of host keys to be active in /etc/ssh/sshd_config file

--- a/roles/ssh/tasks/main.yml
+++ b/roles/ssh/tasks/main.yml
@@ -3,16 +3,24 @@
 - name: Merge default and user config
   set_fact:
     ssh_sshd_config: "{{ ssh_sshd_default_config_options | combine(ssh_sshd_user_config_options) }}"
-  tags: [ssh]
+  tags: [ ssh ]
 
-- name: Configure /etc/ssh/sshd_config file
+- name: Add a file with additional sshd rules
+  template:
+    src: sshd_config.j2
+    dest: /etc/ssh/sshd_config.d/25-ansible.conf
+    owner: root
+    group: root
+    mode: 0600
+  tags: [ ssh ]
+
+- name: Ensure that sshd includes additional configs
   lineinfile:
     path: /etc/ssh/sshd_config
-    line: "{{ item.key }} {{ item.value }}"
-    regexp: "^#?{{ item.key }}"
-  with_dict: "{{ ssh_sshd_config }}"
+    line: "Include /etc/ssh/sshd_config.d/*.conf"
+    state: present
   notify: restart sshd
-  tags: [ssh]
+  tags: [ ssh ]
 
 - name: Enable HostKeys in /etc/ssh/sshd_config
   lineinfile:
@@ -21,7 +29,7 @@
     state: present
   with_items: "{{ ssh_sshd_host_keys }}"
   notify: restart sshd
-  tags: [ssh]
+  tags: [ ssh ]
 
 - name: Disable all other HostKeys in /etc/ssh/sshd_config
   lineinfile:
@@ -29,15 +37,15 @@
     regexp: "HostKey /etc/ssh/(?!{{ ssh_sshd_host_keys | join('|') }})"
     state: absent
   notify: restart sshd
-  tags: [ssh]
+  tags: [ ssh ]
 
 
 
-# Make sure that sshd service is started and enabled on boot
+# Make sure that the sshd service is started and enabled on boot
 #
-- name: Make sure that sshd service is started and enabled on boot
+- name: Make sure that the sshd service is started and enabled on boot
   service:
     name: sshd
     state: started
     enabled: yes
-  tags: [ssh]
+  tags: [ ssh ]

--- a/roles/ssh/templates/sshd_config.j2
+++ b/roles/ssh/templates/sshd_config.j2
@@ -1,0 +1,4 @@
+# This file is managed by Ansible
+{% for key in ssh_sshd_config %}
+{{ key }} {{ ssh_sshd_config[key] }}
+{% endfor %}


### PR DESCRIPTION
Update AWS CLI to 2.9.21
Mark centos, datadog, httpd, openssl roles as deprecated. They will be removed in the future versions.
Update git to 2.39.1
Update MySQL to 8.0.32
Remove local tags from all roles
Fix installation of MySQL on RockyLinux
Update nginx to 1.23.3 with internal dependencies
Update nodejs to 19.6.0
Update PHP to 8.2.2
Fix PHP installation on RockyLInux 
Update Redis to 7.0.8
Fix missing tar command when installing git on RockyLinux
Fix missing packages in the nginx role on RockyLinux
Move the additional rules from /etc/ssh/sshd_config to separate file
Add .idea to gitignore file
Fix not working php extensions for version update
Update README file about the project
Change default password for redis